### PR TITLE
Axis module: rules-compliant logic + commands

### DIFF
--- a/SkyTeam.Domain.Tests/AxisPositionModuleTests.cs
+++ b/SkyTeam.Domain.Tests/AxisPositionModuleTests.cs
@@ -1,0 +1,85 @@
+namespace SkyTeam.Domain.Tests;
+
+using System.Linq;
+using FluentAssertions;
+
+public class AxisPositionModuleTests
+{
+    [Fact]
+    public void AssignBlueDie_ShouldThrow_WhenBlueDieAlreadyAssigned()
+    {
+        // Arrange
+        var module = new AxisPositionModule();
+        module.AssignBlueDie(BlueDie.FromValue(3));
+
+        // Act
+        var assigningAgain = () => module.AssignBlueDie(BlueDie.FromValue(4));
+
+        // Assert
+        assigningAgain.Should().Throw<InvalidOperationException>()
+            .WithMessage("Blue die already assigned.");
+    }
+
+    [Fact]
+    public void AssignOrangeDie_ShouldThrow_WhenOrangeDieAlreadyAssigned()
+    {
+        // Arrange
+        var module = new AxisPositionModule();
+        module.AssignOrangeDie(OrangeDie.FromValue(3));
+
+        // Act
+        var assigningAgain = () => module.AssignOrangeDie(OrangeDie.FromValue(4));
+
+        // Assert
+        assigningAgain.Should().Throw<InvalidOperationException>()
+            .WithMessage("Orange die already assigned.");
+    }
+
+    [Fact]
+    public void AssignDice_ShouldRotateAxisTowardHigherDieByDifference_WhenBothDiceAreAssigned()
+    {
+        // Arrange
+        var module = new AxisPositionModule();
+
+        // Act
+        module.AssignBlueDie(BlueDie.FromValue(4));
+        module.AssignOrangeDie(OrangeDie.FromValue(5));
+
+        // Assert
+        module.AxisPosition.Should().Be(-1);
+    }
+
+    [Fact]
+    public void ResetRound_ShouldClearDiceAssignments_ButKeepAxisPosition()
+    {
+        // Arrange
+        var module = new AxisPositionModule();
+        module.AssignBlueDie(BlueDie.FromValue(4));
+        module.AssignOrangeDie(OrangeDie.FromValue(5));
+
+        // Act
+        module.ResetRound();
+
+        // Assert
+        module.CanAcceptBlueDie(Player.Pilot).Should().BeTrue();
+        module.CanAcceptOrangeDie(Player.Copilot).Should().BeTrue();
+        module.AxisPosition.Should().Be(-1);
+    }
+
+    [Fact]
+    public void GetAvailableCommands_ShouldReturnCommandsForUnusedDiceValues_WhenSlotIsEmpty()
+    {
+        // Arrange
+        var module = new AxisPositionModule();
+        var unusedBlueDice = new[] { BlueDie.FromValue(2), BlueDie.FromValue(5) };
+        var unusedOrangeDice = new[] { OrangeDie.FromValue(1), OrangeDie.FromValue(6) };
+
+        // Act
+        var pilotCommands = module.GetAvailableCommands(Player.Pilot, unusedBlueDice, unusedOrangeDice).ToArray();
+        var copilotCommands = module.GetAvailableCommands(Player.Copilot, unusedBlueDice, unusedOrangeDice).ToArray();
+
+        // Assert
+        pilotCommands.Select(c => c.CommandId).Should().BeEquivalentTo(["Axis.AssignBlue:2", "Axis.AssignBlue:5"]);
+        copilotCommands.Select(c => c.CommandId).Should().BeEquivalentTo(["Axis.AssignOrange:1", "Axis.AssignOrange:6"]);
+    }
+}

--- a/SkyTeam.Domain.Tests/GameCommandTests.cs
+++ b/SkyTeam.Domain.Tests/GameCommandTests.cs
@@ -147,7 +147,10 @@ public class GameCommandTests
         public override bool CanAcceptOrangeDie(Player player) => true;
         public override string GetModuleName() => "Test Module";
 
-        public override IEnumerable<GameCommand> GetAvailableCommands(Player currentPlayer) => _commands;
+        public override IEnumerable<GameCommand> GetAvailableCommands(
+            Player currentPlayer,
+            IReadOnlyList<BlueDie> unusedBlueDice,
+            IReadOnlyList<OrangeDie> unusedOrangeDice) => _commands;
     }
 
     private sealed record TestCommand(string Id) : GameCommand

--- a/SkyTeam.Domain/Die.cs
+++ b/SkyTeam.Domain/Die.cs
@@ -9,6 +9,15 @@ record Die
     private int Value { get; }
 
     public static Die Roll() => new(Random.Next(1, 7)); // Returns 1-6
+
+    internal static Die FromValue(int value)
+    {
+        if (value is < 1 or > 6)
+            throw new ArgumentOutOfRangeException(nameof(value), "Die values must be between 1 and 6.");
+
+        return new Die(value);
+    }
+
     public static implicit operator int(Die die) => die.Value;
 }
 
@@ -16,9 +25,12 @@ record BlueDie
 {
     private readonly Die _die;
 
+    private BlueDie(Die die) => _die = die;
     private BlueDie() => _die = Die.Roll();
 
     public static BlueDie Roll() => new();
+
+    internal static BlueDie FromValue(int value) => new(Die.FromValue(value));
 
     public static implicit operator int(BlueDie die) => die._die;
 }
@@ -27,9 +39,12 @@ record OrangeDie
 {
     private readonly Die _die;
 
+    private OrangeDie(Die die) => _die = die;
     private OrangeDie() => _die = Die.Roll();
 
     public static OrangeDie Roll() => new();
+
+    internal static OrangeDie FromValue(int value) => new(Die.FromValue(value));
 
     public static implicit operator int(OrangeDie die) => die._die;
 }

--- a/SkyTeam.Domain/Game.cs
+++ b/SkyTeam.Domain/Game.cs
@@ -38,6 +38,10 @@ class Game
 
         _altitude.Advance();
         _state.SetCurrentPlayer(_altitude.CurrentPlayer);
+
+        foreach (var module in _modules)
+            module.ResetRound();
+
         RollDice();
     }
 
@@ -56,7 +60,7 @@ class Game
         }
 
         foreach (var gameCommand in _modules.SelectMany(module =>
-                     module.GetAvailableCommands(_state.CurrentPlayer)))
+                     module.GetAvailableCommands(_state.CurrentPlayer, _state.UnusedBlueDice, _state.UnusedOrangeDice)))
             yield return gameCommand;
     }
 

--- a/SkyTeam.Domain/GameModule.cs
+++ b/SkyTeam.Domain/GameModule.cs
@@ -17,5 +17,12 @@ abstract class GameModule
     /// </summary>
     public abstract string GetModuleName();
 
-    public abstract IEnumerable<GameCommand> GetAvailableCommands(Player currentPlayer);
+    public abstract IEnumerable<GameCommand> GetAvailableCommands(
+        Player currentPlayer,
+        IReadOnlyList<BlueDie> unusedBlueDice,
+        IReadOnlyList<OrangeDie> unusedOrangeDice);
+
+    public virtual void ResetRound()
+    {
+    }
 }


### PR DESCRIPTION
Implements AxisPositionModule per rules spec (#14), including:\n- persistent axis position with loss bounds\n- per-round die assignment reset\n- command generation based on unused dice values\n- deterministic dice factories for tests\n\nCloses #3.