### PR TITLE
Engines module + approach track state

### DIFF
--- a/SkyTeam.Domain.Tests/EnginesModuleTests.cs
+++ b/SkyTeam.Domain.Tests/EnginesModuleTests.cs
@@ -1,0 +1,119 @@
+namespace SkyTeam.Domain.Tests;
+
+using System.Linq;
+using FluentAssertions;
+
+public class EnginesModuleTests
+{
+    [Fact]
+    public void AssignDice_ShouldNotAdvanceApproach_WhenSpeedIsBelowBlueThreshold()
+    {
+        // Arrange
+        var airport = (Airport)new MontrealAirport();
+        var module = new EnginesModule(airport);
+
+        // Act
+        module.AssignBlueDie(BlueDie.FromValue(1));
+        module.AssignOrangeDie(OrangeDie.FromValue(3));
+
+        // Assert
+        module.LastSpeed.Should().Be(4);
+        airport.CurrentPositionIndex.Should().Be(0);
+    }
+
+    [Fact]
+    public void AssignDice_ShouldAdvanceApproachByOne_WhenSpeedIsBetweenBlueAndOrangeThresholds()
+    {
+        // Arrange
+        var airport = (Airport)new MontrealAirport();
+        var module = new EnginesModule(airport);
+
+        // Act
+        module.AssignBlueDie(BlueDie.FromValue(4));
+        module.AssignOrangeDie(OrangeDie.FromValue(3));
+
+        // Assert
+        module.LastSpeed.Should().Be(7);
+        airport.CurrentPositionIndex.Should().Be(1);
+    }
+
+    [Fact]
+    public void AssignDice_ShouldAdvanceApproachByTwo_WhenSpeedIsAboveOrangeThreshold()
+    {
+        // Arrange
+        var airport = (Airport)new MontrealAirport();
+        var module = new EnginesModule(airport);
+
+        // Act
+        module.AssignBlueDie(BlueDie.FromValue(6));
+        module.AssignOrangeDie(OrangeDie.FromValue(6));
+
+        // Assert
+        module.LastSpeed.Should().Be(12);
+        airport.CurrentPositionIndex.Should().Be(2);
+    }
+
+    [Fact]
+    public void AssignDice_ShouldThrow_WhenAdvancingFromCurrentPositionWithAirplanes()
+    {
+        // Arrange
+        var airport = (Airport)new MontrealAirport();
+        var module = new EnginesModule(airport);
+
+        // Reach a segment with airplanes (allowed).
+        module.AssignBlueDie(BlueDie.FromValue(6));
+        module.AssignOrangeDie(OrangeDie.FromValue(6));
+
+        airport.CurrentSegment.PlaneTokens.Should().BeGreaterThan(0);
+
+        module.ResetRound();
+
+        // Act
+        var resolving = () =>
+        {
+            module.AssignBlueDie(BlueDie.FromValue(4));
+            module.AssignOrangeDie(OrangeDie.FromValue(3));
+        };
+
+        // Assert
+        resolving.Should().Throw<InvalidOperationException>()
+            .WithMessage("Cannot advance approach with airplanes at current position.");
+    }
+
+    [Fact]
+    public void AssignDice_ShouldThrow_WhenApproachWouldOvershoot()
+    {
+        // Arrange
+        var airport = new Airport([new PathSegment(0)]);
+        var module = new EnginesModule(airport);
+
+        // Act
+        var resolving = () =>
+        {
+            module.AssignBlueDie(BlueDie.FromValue(4));
+            module.AssignOrangeDie(OrangeDie.FromValue(3));
+        };
+
+        // Assert
+        resolving.Should().Throw<InvalidOperationException>()
+            .WithMessage("Approach overshoot.");
+    }
+
+    [Fact]
+    public void GetAvailableCommands_ShouldReturnCommandsForUnusedDiceValues_WhenSlotIsEmpty()
+    {
+        // Arrange
+        var airport = (Airport)new MontrealAirport();
+        var module = new EnginesModule(airport);
+        var unusedBlueDice = new[] { BlueDie.FromValue(2), BlueDie.FromValue(5) };
+        var unusedOrangeDice = new[] { OrangeDie.FromValue(1), OrangeDie.FromValue(6) };
+
+        // Act
+        var pilotCommands = module.GetAvailableCommands(Player.Pilot, unusedBlueDice, unusedOrangeDice).ToArray();
+        var copilotCommands = module.GetAvailableCommands(Player.Copilot, unusedBlueDice, unusedOrangeDice).ToArray();
+
+        // Assert
+        pilotCommands.Select(c => c.CommandId).Should().BeEquivalentTo(["Engines.AssignBlue:2", "Engines.AssignBlue:5"]);
+        copilotCommands.Select(c => c.CommandId).Should().BeEquivalentTo(["Engines.AssignOrange:1", "Engines.AssignOrange:6"]);
+    }
+}

--- a/SkyTeam.Domain/Airport.cs
+++ b/SkyTeam.Domain/Airport.cs
@@ -1,11 +1,62 @@
 ﻿namespace SkyTeam.Domain;
 
-class Airport(IEnumerable<PathSegment> pathSegments)
+sealed class Airport
 {
-    public Queue<PathSegment> PathSegments { get; } = new(pathSegments);
+    private readonly PathSegment[] _segments;
+    private int _currentPositionIndex;
+
+    internal double BlueAerodynamicsThreshold { get; private set; } = 4.5;
+    internal double OrangeAerodynamicsThreshold { get; private set; } = 8.5;
+
+    public Airport(IEnumerable<PathSegment> pathSegments)
+    {
+        ArgumentNullException.ThrowIfNull(pathSegments);
+
+        _segments = pathSegments.ToArray();
+    }
+
+    // Compatibility surface for existing tests.
+    internal IReadOnlyList<PathSegment> PathSegments => _segments;
+
+    internal int CurrentPositionIndex => _currentPositionIndex;
+    internal int SegmentCount => _segments.Length;
+    internal PathSegment CurrentSegment => _segments[_currentPositionIndex];
+
+    internal void AdvanceApproach(int steps)
+    {
+        if (steps < 0)
+            throw new ArgumentOutOfRangeException(nameof(steps), "Steps must be non-negative.");
+
+        if (steps == 0) return;
+
+        if (_segments.Length == 0)
+            throw new InvalidOperationException("Cannot advance approach when no path segments exist.");
+
+        if (CurrentSegment.PlaneTokens > 0)
+            throw new InvalidOperationException("Cannot advance approach with airplanes at current position.");
+
+        if (_currentPositionIndex + steps >= _segments.Length)
+            throw new InvalidOperationException("Approach overshoot.");
+
+        _currentPositionIndex += steps;
+    }
+
+    internal bool TryRemovePlaneTokenAtOffset(int offsetFromCurrent)
+    {
+        if (offsetFromCurrent < 0)
+            throw new ArgumentOutOfRangeException(nameof(offsetFromCurrent));
+
+        var index = _currentPositionIndex + offsetFromCurrent;
+        if (index >= _segments.Length) return false;
+
+        return _segments[index].TryRemovePlaneToken();
+    }
+
+    internal void MoveBlueAerodynamicsRight() => BlueAerodynamicsThreshold += 1;
+    internal void MoveOrangeAerodynamicsRight() => OrangeAerodynamicsThreshold += 1;
 }
 
-class MontrealAirport
+sealed class MontrealAirport
 {
     private readonly Airport _airport = new([
         new(0),
@@ -20,4 +71,26 @@ class MontrealAirport
     public static implicit operator Airport(MontrealAirport airport) => airport._airport;
 }
 
-record PathSegment(int NumberOfPlanes);
+sealed class PathSegment
+{
+    internal int PlaneTokens { get; private set; }
+
+    // Compatibility surface for existing tests.
+    internal int NumberOfPlanes => PlaneTokens;
+
+    public PathSegment(int planeTokens)
+    {
+        if (planeTokens < 0)
+            throw new ArgumentOutOfRangeException(nameof(planeTokens), "Plane token count must be non-negative.");
+
+        PlaneTokens = planeTokens;
+    }
+
+    internal bool TryRemovePlaneToken()
+    {
+        if (PlaneTokens == 0) return false;
+
+        PlaneTokens--;
+        return true;
+    }
+}

--- a/SkyTeam.Domain/EnginesModule.cs
+++ b/SkyTeam.Domain/EnginesModule.cs
@@ -1,0 +1,133 @@
+namespace SkyTeam.Domain;
+
+sealed class EnginesModule(Airport airport) : GameModule
+{
+    private readonly Airport _airport = airport ?? throw new ArgumentNullException(nameof(airport));
+
+    private BlueDie? _blueDie;
+    private OrangeDie? _orangeDie;
+
+    internal int? LastSpeed { get; private set; }
+
+    public override bool CanAcceptBlueDie(Player player) =>
+        player == Player.Pilot && _blueDie is null;
+
+    public override bool CanAcceptOrangeDie(Player player) =>
+        player == Player.Copilot && _orangeDie is null;
+
+    public override string GetModuleName() => "Engines";
+
+    public override IEnumerable<GameCommand> GetAvailableCommands(
+        Player currentPlayer,
+        IReadOnlyList<BlueDie> unusedBlueDice,
+        IReadOnlyList<OrangeDie> unusedOrangeDice)
+    {
+        if (currentPlayer == Player.Pilot && _blueDie is null)
+        {
+            foreach (var value in unusedBlueDice.Select(die => (int)die).Distinct().Order())
+                yield return CreateBlueCommand(value);
+        }
+
+        if (currentPlayer == Player.Copilot && _orangeDie is null)
+        {
+            foreach (var value in unusedOrangeDice.Select(die => (int)die).Distinct().Order())
+                yield return CreateOrangeCommand(value);
+        }
+    }
+
+    public void AssignBlueDie(BlueDie die)
+    {
+        ArgumentNullException.ThrowIfNull(die);
+
+        if (_blueDie is not null)
+            throw new InvalidOperationException("Blue die already assigned.");
+
+        _blueDie = die;
+        ResolveEnginesIfReady();
+    }
+
+    public void AssignOrangeDie(OrangeDie die)
+    {
+        ArgumentNullException.ThrowIfNull(die);
+
+        if (_orangeDie is not null)
+            throw new InvalidOperationException("Orange die already assigned.");
+
+        _orangeDie = die;
+        ResolveEnginesIfReady();
+    }
+
+    public override void ResetRound()
+    {
+        _blueDie = null;
+        _orangeDie = null;
+        LastSpeed = null;
+    }
+
+    private void ResolveEnginesIfReady()
+    {
+        if (_blueDie is null || _orangeDie is null) return;
+
+        var speed = (int)_blueDie + (int)_orangeDie;
+        LastSpeed = speed;
+
+        var advanceBy = CalculateApproachAdvance(speed);
+        _airport.AdvanceApproach(advanceBy);
+    }
+
+    private int CalculateApproachAdvance(int speed)
+    {
+        if (speed < _airport.BlueAerodynamicsThreshold) return 0;
+        if (speed <= _airport.OrangeAerodynamicsThreshold) return 1;
+
+        return 2;
+    }
+
+    private GameCommand CreateBlueCommand(int value)
+    {
+        EnginesPlacementPreview? preview = null;
+
+        if (_orangeDie is not null)
+            preview = GetPreview(value + (int)_orangeDie);
+
+        return new AssignEnginesBlueDieCommand(value, preview);
+    }
+
+    private GameCommand CreateOrangeCommand(int value)
+    {
+        EnginesPlacementPreview? preview = null;
+
+        if (_blueDie is not null)
+            preview = GetPreview((int)_blueDie + value);
+
+        return new AssignEnginesOrangeDieCommand(value, preview);
+    }
+
+    private EnginesPlacementPreview GetPreview(int speed)
+    {
+        var advanceBy = CalculateApproachAdvance(speed);
+        var resultingPosition = _airport.CurrentPositionIndex + advanceBy;
+
+        return new EnginesPlacementPreview(speed, advanceBy, resultingPosition);
+    }
+
+    private sealed record EnginesPlacementPreview(int Speed, int AdvanceBy, int ResultingPosition);
+
+    private sealed record AssignEnginesBlueDieCommand(int Value, EnginesPlacementPreview? Preview) : GameCommand
+    {
+        public override string CommandId => $"Engines.AssignBlue:{Value}";
+
+        public override string DisplayName => Preview is null
+            ? $"Engines: place blue {Value}"
+            : $"Engines: place blue {Value} (speed {Preview.Speed}, advance {Preview.AdvanceBy})";
+    }
+
+    private sealed record AssignEnginesOrangeDieCommand(int Value, EnginesPlacementPreview? Preview) : GameCommand
+    {
+        public override string CommandId => $"Engines.AssignOrange:{Value}";
+
+        public override string DisplayName => Preview is null
+            ? $"Engines: place orange {Value}"
+            : $"Engines: place orange {Value} (speed {Preview.Speed}, advance {Preview.AdvanceBy})";
+    }
+}


### PR DESCRIPTION
Implements EnginesModule (issue #4):\n- pilot+copilot die placement (one per round)\n- speed sum -> advance 0/1/2 based on aerodynamics thresholds\n- collision + overshoot validation\n- command generation based on unused dice values\n\nIncludes an Airport refactor to track approach position + airplane tokens (keeps PathSegments/NumberOfPlanes compatibility for existing tests).\n\nCloses #4.