### PR TITLE
Telegram: DM secret dice roll to seated players (#29)

### DIFF
--- a/.squad/decisions/inbox/skiles-29-secret-dice.md
+++ b/.squad/decisions/inbox/skiles-29-secret-dice.md
@@ -1,0 +1,12 @@
+# Decision: Secret dice roll via DM (Issue #29)
+
+## Context
+We need to keep dice values secret between seated players while still rolling from the group chat.
+
+## Decision
+- Add a `/sky roll` group command.
+- On roll, generate 4 dice values (1–6) for each seat and DM them to the seated Pilot/Copilot.
+- If a DM fails (player has not `/start`ed the bot privately), notify the group without revealing any dice values.
+
+## Rationale
+This keeps the change minimal and testable (pure application dice-roll logic), while matching Telegram constraints around private messaging.

--- a/SkyTeam.Application.Tests/Round/SecretDiceRollerTests.cs
+++ b/SkyTeam.Application.Tests/Round/SecretDiceRollerTests.cs
@@ -1,0 +1,47 @@
+namespace SkyTeam.Application.Tests.Round;
+
+using FluentAssertions;
+using SkyTeam.Application.Round;
+
+public sealed class SecretDiceRollerTests
+{
+    [Fact]
+    public void Roll_ShouldReturnDiceForEachSeat_WhenRollerProducesValidValues()
+    {
+        // Arrange
+        var values = new Queue<int>([1, 2, 3, 4, 5, 6, 1, 2]);
+
+        // Act
+        var result = SecretDiceRoller.Roll(() => values.Dequeue(), dicePerSeat: 4);
+
+        // Assert
+        result.PilotDice.Should().Equal(1, 2, 3, 4);
+        result.CopilotDice.Should().Equal(5, 6, 1, 2);
+    }
+
+    [Fact]
+    public void Roll_ShouldThrowArgumentOutOfRangeException_WhenDicePerSeatIsLessThanOne()
+    {
+        // Arrange
+        var rollDie = () => 1;
+
+        // Act
+        var invoking = () => SecretDiceRoller.Roll(rollDie, dicePerSeat: 0);
+
+        // Assert
+        invoking.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void Roll_ShouldThrowInvalidOperationException_WhenRollerProducesValueOutsideRange()
+    {
+        // Arrange
+        var rollDie = () => 7;
+
+        // Act
+        var invoking = () => SecretDiceRoller.Roll(rollDie);
+
+        // Assert
+        invoking.Should().Throw<InvalidOperationException>();
+    }
+}

--- a/SkyTeam.Application/Round/SecretDiceRoll.cs
+++ b/SkyTeam.Application/Round/SecretDiceRoll.cs
@@ -1,0 +1,3 @@
+namespace SkyTeam.Application.Round;
+
+public sealed record SecretDiceRoll(IReadOnlyList<int> PilotDice, IReadOnlyList<int> CopilotDice);

--- a/SkyTeam.Application/Round/SecretDiceRoller.cs
+++ b/SkyTeam.Application/Round/SecretDiceRoller.cs
@@ -1,0 +1,31 @@
+namespace SkyTeam.Application.Round;
+
+public static class SecretDiceRoller
+{
+    public static SecretDiceRoll Roll(Func<int> rollDie, int dicePerSeat = 4)
+    {
+        ArgumentNullException.ThrowIfNull(rollDie);
+        if (dicePerSeat < 1)
+            throw new ArgumentOutOfRangeException(nameof(dicePerSeat), dicePerSeat, "Must roll at least one die per seat.");
+
+        return new SecretDiceRoll(
+            PilotDice: RollMany(rollDie, dicePerSeat),
+            CopilotDice: RollMany(rollDie, dicePerSeat));
+    }
+
+    private static int[] RollMany(Func<int> rollDie, int count)
+    {
+        var dice = new int[count];
+
+        for (var i = 0; i < count; i++)
+        {
+            var value = rollDie();
+            if (value is < 1 or > 6)
+                throw new InvalidOperationException("Die roller produced an invalid value.");
+
+            dice[i] = value;
+        }
+
+        return dice;
+    }
+}

--- a/SkyTeam.TelegramBot/Program.cs
+++ b/SkyTeam.TelegramBot/Program.cs
@@ -1,6 +1,7 @@
 namespace SkyTeam.TelegramBot;
 
 using SkyTeam.Application.Lobby;
+using SkyTeam.Application.Round;
 using Telegram.Bot;
 using Telegram.Bot.Polling;
 using Telegram.Bot.Types;
@@ -101,10 +102,14 @@ internal static class Program
                 await HandleSkyStateAsync(botClient, message, cancellationToken);
                 return;
 
+            case "roll":
+                await HandleSkyRollAsync(botClient, message, cancellationToken);
+                return;
+
             default:
                 await botClient.SendMessage(
                     chatId: message.Chat.Id,
-                    text: "Usage: /sky new | /sky join | /sky state",
+                    text: "Usage: /sky new | /sky join | /sky state | /sky roll",
                     cancellationToken: cancellationToken);
                 return;
         }
@@ -182,6 +187,75 @@ internal static class Program
             chatId: message.Chat.Id,
             text: RenderLobby(snapshot),
             cancellationToken: cancellationToken);
+    }
+
+    private static async Task HandleSkyRollAsync(ITelegramBotClient botClient, Message message, CancellationToken cancellationToken)
+    {
+        var snapshot = LobbyStore.GetSnapshot(message.Chat.Id);
+        if (snapshot is null)
+        {
+            await botClient.SendMessage(
+                chatId: message.Chat.Id,
+                text: "No lobby yet. Create one with /sky new",
+                cancellationToken: cancellationToken);
+            return;
+        }
+
+        if (!snapshot.IsReady)
+        {
+            await botClient.SendMessage(
+                chatId: message.Chat.Id,
+                text: "Lobby is not ready yet. Two players must /sky join before rolling dice.",
+                cancellationToken: cancellationToken);
+            return;
+        }
+
+        var roll = SecretDiceRoller.Roll(() => Random.Shared.Next(1, 7));
+
+        var failedRecipients = new List<string>(capacity: 2);
+
+        if (!await TrySendSecretDiceAsync(botClient, snapshot.Pilot!, "Pilot", roll.PilotDice, cancellationToken))
+            failedRecipients.Add(snapshot.Pilot!.DisplayName);
+
+        if (!await TrySendSecretDiceAsync(botClient, snapshot.Copilot!, "Copilot", roll.CopilotDice, cancellationToken))
+            failedRecipients.Add(snapshot.Copilot!.DisplayName);
+
+        var groupText = failedRecipients.Count == 0
+            ? "Dice rolled and sent privately to seated players."
+            : $"Dice rolled, but I couldn't DM: {string.Join(", ", failedRecipients)}. Each seated player must /start me in a private chat first.";
+
+        await botClient.SendMessage(
+            chatId: message.Chat.Id,
+            text: groupText,
+            cancellationToken: cancellationToken);
+    }
+
+    private static async Task<bool> TrySendSecretDiceAsync(
+        ITelegramBotClient botClient,
+        LobbyPlayer recipient,
+        string seat,
+        IReadOnlyList<int> dice,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(recipient);
+        ArgumentNullException.ThrowIfNull(dice);
+
+        var diceText = string.Join(", ", dice);
+
+        try
+        {
+            await botClient.SendMessage(
+                chatId: recipient.UserId,
+                text: $"{seat} secret dice: {diceText}",
+                cancellationToken: cancellationToken);
+
+            return true;
+        }
+        catch (Exception exception)
+        {
+            Console.Error.WriteLine(exception);
+            return false;
+        }
     }
 
     private static string RenderLobby(LobbySnapshot snapshot)


### PR DESCRIPTION
Implements secret dice rolling via /sky roll: rolls 4 dice per seat and DMs Pilot/Copilot their values (no dice revealed in group chat). Includes a small application-layer SecretDiceRoller with unit tests, plus a decision note.\n\nCloses #29.\n\nTests: dotnet test -c Release